### PR TITLE
Add admin index fixture support

### DIFF
--- a/bin/generate_admin_index_fixture.sh
+++ b/bin/generate_admin_index_fixture.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#
+
+# Dump the current (local database) admin layout to a JSON fixture. This
+
+# overwrites the existing one.
+
+#
+
+# You can load this fixture with:
+
+# $ src/manage.py loaddata default_admin_index
+
+#
+
+# Run this script from the root of the repository
+
+mkdir -p src/open_producten/fixtures
+
+src/manage.py dumpdata --indent=4 --natural-foreign --natural-primary admin_index.AppGroup admin_index.AppLink > src/open_producten/fixtures/default_admin_index.json

--- a/src/open_producten/accounts/apps.py
+++ b/src/open_producten/accounts/apps.py
@@ -1,5 +1,43 @@
-from django.apps import AppConfig
+import logging
+from io import StringIO
+
+from django.apps import AppConfig, apps
+from django.conf import settings
+from django.contrib.contenttypes.management import create_contenttypes
+from django.core.management import call_command
+from django.db.models.signals import post_migrate
+
+logger = logging.getLogger(__name__)
+
+
+def update_admin_index(sender, **kwargs):
+    if "django_admin_index" not in settings.INSTALLED_APPS:
+        logger.warning(
+            "django_admin_index is not installed: skipping update_admin_index()"
+        )
+        return
+
+    from django_admin_index.models import AppGroup
+
+    AppGroup.objects.all().delete()
+
+    # Make sure project models are registered.
+    project_name = __name__.split(".")[0]
+
+    for app_config in apps.get_app_configs():
+        if app_config.name.startswith(project_name):
+            create_contenttypes(app_config, verbosity=0)
+
+    try:
+        call_command("loaddata", "default_admin_index", verbosity=0, stdout=StringIO())
+    except Exception as exc:
+        logger.warning(f"Unable to load default_admin_index fixture ({exc})")
+        return
+    logger.info("Loaded django-admin-index fixture")
 
 
 class AccountsConfig(AppConfig):
     name = "open_producten.accounts"
+
+    def ready(self):
+        post_migrate.connect(update_admin_index, sender=self)

--- a/src/open_producten/accounts/apps.py
+++ b/src/open_producten/accounts/apps.py
@@ -27,13 +27,15 @@ def update_admin_index(sender, **kwargs):
     for app_config in apps.get_app_configs():
         if app_config.name.startswith(project_name):
             create_contenttypes(app_config, verbosity=0)
-
+    out = StringIO()
     try:
-        call_command("loaddata", "default_admin_index", verbosity=0, stdout=StringIO())
+        call_command("loaddata", "default_admin_index", verbosity=0, stdout=out)
     except Exception as exc:
-        logger.warning(f"Unable to load default_admin_index fixture ({exc})")
+        logger.warning(
+            f"Unable to load default_admin_index fixture ({exc}). You might have to regenerate the fixtures through 'bin/generate_admin_index_fixtures.sh'"
+        )
         return
-    logger.info("Loaded django-admin-index fixture")
+    logger.info("Loaded django-admin-index fixture:\n%s", out.getvalue())
 
 
 class AccountsConfig(AppConfig):

--- a/src/open_producten/accounts/tests/test_admin_index.py
+++ b/src/open_producten/accounts/tests/test_admin_index.py
@@ -1,0 +1,48 @@
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+from .. import apps as accounts_apps
+
+
+class DjangoAdminConfigTests(TestCase):
+
+    @override_settings(INSTALLED_APPS=[])
+    def test_update_admin_index_without_admin_index(self):
+        with self.assertLogs(accounts_apps.__name__, level="WARNING") as cm:
+            accounts_apps.update_admin_index(None)
+
+        self.assertEqual(
+            cm.output,
+            [
+                f"WARNING:{accounts_apps.__name__}:django_admin_index is not installed: skipping update_admin_index()"
+            ],
+        )
+
+    @mock.patch("open_producten.accounts.apps.call_command")
+    @override_settings(INSTALLED_APPS=["django_admin_index"])
+    def test_update_admin_index_without_fixture(self, mock_call_command):
+        mock_call_command.side_effect = ImportError()
+
+        with self.assertLogs(accounts_apps.__name__, level="WARNING") as cm:
+            accounts_apps.update_admin_index(None)
+
+        self.assertEqual(
+            cm.output,
+            [
+                f"WARNING:{accounts_apps.__name__}:Unable to load default_admin_index fixture ()"
+            ],
+        )
+
+    @mock.patch("open_producten.accounts.apps.call_command")
+    @override_settings(INSTALLED_APPS=["django_admin_index"])
+    def test_update_admin_index_with_fixture(self, mock_call_command):
+        with self.assertLogs(accounts_apps.__name__, level="INFO") as cm:
+            accounts_apps.update_admin_index(None)
+
+        self.assertEqual(mock_call_command.call_count, 1)
+
+        self.assertEqual(
+            cm.output,
+            [f"INFO:{accounts_apps.__name__}:Loaded django-admin-index fixture"],
+        )

--- a/src/open_producten/accounts/tests/test_admin_index.py
+++ b/src/open_producten/accounts/tests/test_admin_index.py
@@ -30,7 +30,7 @@ class DjangoAdminConfigTests(TestCase):
         self.assertEqual(
             cm.output,
             [
-                f"WARNING:{accounts_apps.__name__}:Unable to load default_admin_index fixture ()"
+                f"WARNING:{accounts_apps.__name__}:Unable to load default_admin_index fixture (). You might have to regenerate the fixtures through 'bin/generate_admin_index_fixtures.sh'"
             ],
         )
 
@@ -44,5 +44,5 @@ class DjangoAdminConfigTests(TestCase):
 
         self.assertEqual(
             cm.output,
-            [f"INFO:{accounts_apps.__name__}:Loaded django-admin-index fixture"],
+            [f"INFO:{accounts_apps.__name__}:Loaded django-admin-index fixture:\n"],
         )

--- a/src/open_producten/conf/base.py
+++ b/src/open_producten/conf/base.py
@@ -57,6 +57,8 @@ ADMIN_INDEX_DISPLAY_DROP_DOWN_MENU_CONDITION_FUNCTION = (
     "open_producten.utils.django_two_factor_auth.should_display_dropdown_menu"
 )
 
+ADMIN_INDEX_SHOW_REMAINING_APPS = False
+
 #
 # Django rest framework
 #

--- a/src/open_producten/conf/base.py
+++ b/src/open_producten/conf/base.py
@@ -23,12 +23,6 @@ INSTALLED_APPS += [
 ]
 
 #
-# FIXTURES
-#
-
-FIXTURE_DIRS = (DJANGO_PROJECT_DIR / "fixtures",)
-
-#
 # Custom settings
 #
 PROJECT_NAME = "open_producten"

--- a/src/open_producten/fixtures/default_admin_index.json
+++ b/src/open_producten/fixtures/default_admin_index.json
@@ -1,0 +1,265 @@
+[
+{
+    "model": "admin_index.appgroup",
+    "fields": {
+        "order": 0,
+        "translations": {
+            "nl": "Producten"
+        },
+        "name": "Products",
+        "slug": "products",
+        "models": [
+            [
+                "products",
+                "data"
+            ],
+            [
+                "products",
+                "product"
+            ]
+        ]
+    }
+},
+{
+    "model": "admin_index.appgroup",
+    "fields": {
+        "order": 1,
+        "translations": {
+            "nl": "Product typen"
+        },
+        "name": "Product types",
+        "slug": "product-types",
+        "models": [
+            [
+                "producttypes",
+                "category"
+            ],
+            [
+                "producttypes",
+                "categoryproducttype"
+            ],
+            [
+                "producttypes",
+                "condition"
+            ],
+            [
+                "producttypes",
+                "field"
+            ],
+            [
+                "producttypes",
+                "file"
+            ],
+            [
+                "producttypes",
+                "link"
+            ],
+            [
+                "producttypes",
+                "price"
+            ],
+            [
+                "producttypes",
+                "priceoption"
+            ],
+            [
+                "producttypes",
+                "producttype"
+            ],
+            [
+                "producttypes",
+                "question"
+            ],
+            [
+                "producttypes",
+                "tag"
+            ],
+            [
+                "producttypes",
+                "tagtype"
+            ],
+            [
+                "producttypes",
+                "uniformproductname"
+            ]
+        ]
+    }
+},
+{
+    "model": "admin_index.appgroup",
+    "fields": {
+        "order": 2,
+        "translations": {
+            "nl": "Gebruikers"
+        },
+        "name": "Users",
+        "slug": "users",
+        "models": [
+            [
+                "accounts",
+                "user"
+            ],
+            [
+                "auth",
+                "group"
+            ],
+            [
+                "auth",
+                "permission"
+            ],
+            [
+                "otp_static",
+                "staticdevice"
+            ],
+            [
+                "otp_static",
+                "statictoken"
+            ],
+            [
+                "otp_totp",
+                "totpdevice"
+            ]
+        ]
+    }
+},
+{
+    "model": "admin_index.appgroup",
+    "fields": {
+        "order": 3,
+        "translations": {
+            "nl": "Configuratie"
+        },
+        "name": "Config",
+        "slug": "config",
+        "models": [
+            [
+                "admin_index",
+                "appgroup"
+            ],
+            [
+                "admin_index",
+                "applink"
+            ],
+            [
+                "admin_index",
+                "contenttypeproxy"
+            ]
+        ]
+    }
+},
+{
+    "model": "admin_index.appgroup",
+    "fields": {
+        "order": 4,
+        "translations": {
+            "nl": "Integraties"
+        },
+        "name": "Integrations",
+        "slug": "integrations",
+        "models": [
+            [
+                "vng_api_common",
+                "jwtsecret"
+            ]
+        ]
+    }
+},
+{
+    "model": "admin_index.appgroup",
+    "fields": {
+        "order": 6,
+        "translations": {
+            "nl": "Misc"
+        },
+        "name": "Misc",
+        "slug": "all",
+        "models": [
+            [
+                "contenttypes",
+                "contenttype"
+            ],
+            [
+                "log_outgoing_requests",
+                "outgoingrequestslog"
+            ],
+            [
+                "log_outgoing_requests",
+                "outgoingrequestslogconfig"
+            ],
+            [
+                "mozilla_django_oidc_db",
+                "openidconnectconfig"
+            ],
+            [
+                "notifications_api_common",
+                "notificationsconfig"
+            ],
+            [
+                "notifications_api_common",
+                "subscription"
+            ],
+            [
+                "sessions",
+                "session"
+            ],
+            [
+                "simple_certmanager",
+                "certificate"
+            ],
+            [
+                "sites",
+                "site"
+            ],
+            [
+                "two_factor_webauthn",
+                "webauthndevice"
+            ],
+            [
+                "vng_api_common",
+                "apicredential"
+            ],
+            [
+                "zgw_consumers",
+                "certificate"
+            ],
+            [
+                "zgw_consumers",
+                "nlxconfig"
+            ],
+            [
+                "zgw_consumers",
+                "service"
+            ]
+        ]
+    }
+},
+{
+    "model": "admin_index.appgroup",
+    "fields": {
+        "order": 5,
+        "translations": {
+            "nl": "logs"
+        },
+        "name": "Logs",
+        "slug": "logs",
+        "models": [
+            [
+                "admin",
+                "logentry"
+            ],
+            [
+                "axes",
+                "accessattempt"
+            ],
+            [
+                "axes",
+                "accessfailurelog"
+            ],
+            [
+                "axes",
+                "accesslog"
+            ]
+        ]
+    }
+}
+]

--- a/src/open_producten/fixtures/default_admin_index.json
+++ b/src/open_producten/fixtures/default_admin_index.json
@@ -88,7 +88,7 @@
 {
     "model": "admin_index.appgroup",
     "fields": {
-        "order": 2,
+        "order": 3,
         "translations": {
             "nl": "Gebruikers"
         },
@@ -125,7 +125,7 @@
 {
     "model": "admin_index.appgroup",
     "fields": {
-        "order": 3,
+        "order": 4,
         "translations": {
             "nl": "Configuratie"
         },
@@ -150,7 +150,7 @@
 {
     "model": "admin_index.appgroup",
     "fields": {
-        "order": 4,
+        "order": 5,
         "translations": {
             "nl": "Integraties"
         },
@@ -167,7 +167,7 @@
 {
     "model": "admin_index.appgroup",
     "fields": {
-        "order": 6,
+        "order": 7,
         "translations": {
             "nl": "Misc"
         },
@@ -236,7 +236,7 @@
 {
     "model": "admin_index.appgroup",
     "fields": {
-        "order": 5,
+        "order": 6,
         "translations": {
             "nl": "logs"
         },
@@ -258,6 +258,39 @@
             [
                 "axes",
                 "accesslog"
+            ]
+        ]
+    }
+},
+{
+    "model": "admin_index.appgroup",
+    "fields": {
+        "order": 2,
+        "translations": {
+            "nl": "Locaties & Organisaties"
+        },
+        "name": "Locations & Organisations",
+        "slug": "locations-organisations",
+        "models": [
+            [
+                "locations",
+                "contact"
+            ],
+            [
+                "locations",
+                "location"
+            ],
+            [
+                "locations",
+                "neighbourhood"
+            ],
+            [
+                "locations",
+                "organisation"
+            ],
+            [
+                "locations",
+                "organisationtype"
             ]
         ]
     }


### PR DESCRIPTION
- Adds script to save the current [admin index](https://github.com/maykinmedia/django-admin-index) data.
- Adds a post_migrate hook on the Accounts app to load the stored fixture.

- copied from [pr](https://bitbucket.org/maykinmedia/default-project/pull-requests/94)