### PR TITLE
add custom model validation to serializers

### DIFF
--- a/src/open_producten/producttypes/admin/category.py
+++ b/src/open_producten/producttypes/admin/category.py
@@ -21,26 +21,6 @@ class CategoryAdminForm(movenodeform_factory(Category)):
         model = Category
         fields = "__all__"
 
-    def clean(self, *args, **kwargs):
-        cleaned_data = super().clean(*args, **kwargs)
-
-        published = cleaned_data["published"]
-        ref_node = cleaned_data["_ref_node_id"]
-        if published and ref_node:
-            parent_node = Category.objects.get(id=ref_node)
-            if not parent_node.published:
-                raise forms.ValidationError(
-                    _("Parent nodes have to be published in order to publish a child.")
-                )
-
-        if (
-            not published
-            and self.instance.get_children().filter(published=True).exists()
-        ):
-            raise forms.ValidationError(
-                _("Parent nodes cannot be unpublished if they have published children.")
-            )
-
 
 class CategoryAdminFormSet(BaseModelFormSet):
     def clean(self):

--- a/src/open_producten/producttypes/serializers/category.py
+++ b/src/open_producten/producttypes/serializers/category.py
@@ -48,7 +48,7 @@ class CategorySerializer(serializers.ModelSerializer):
         if errors:
             raise serializers.ValidationError(errors)
 
-    def _clean(self, category):
+    def _validate_category(self, category):
         try:
             category.clean()
         except ValidationError as err:
@@ -64,7 +64,7 @@ class CategorySerializer(serializers.ModelSerializer):
         else:
             category = Category.add_root(**validated_data)
 
-        self._clean(category)
+        self._validate_category(category)
         self._handle_relations(category, product_types)
         category.save()
 
@@ -89,7 +89,7 @@ class CategorySerializer(serializers.ModelSerializer):
             instance.refresh_from_db()
 
         instance = super().update(instance, validated_data)
-        self._clean(instance)
+        self._validate_category(instance)
         self._handle_relations(instance, product_types)
         instance.save()
         return instance

--- a/src/open_producten/producttypes/serializers/children.py
+++ b/src/open_producten/producttypes/serializers/children.py
@@ -96,6 +96,11 @@ class FieldSerializer(serializers.ModelSerializer):
         model = Field
         exclude = ("product_type",)
 
+    def validate(self, attrs):
+        instance = Field(**attrs)
+        instance.clean()
+        return attrs
+
 
 class FileSerializer(serializers.ModelSerializer):
     class Meta:

--- a/src/open_producten/producttypes/serializers/producttype.py
+++ b/src/open_producten/producttypes/serializers/producttype.py
@@ -58,7 +58,6 @@ class ProductTypeSerializer(serializers.ModelSerializer):
         many=True,
         write_only=True,
         queryset=Category.objects.all(),
-        default=[],
         source="categories",
     )
 
@@ -70,6 +69,11 @@ class ProductTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductType
         fields = "__all__"
+
+    def validate_category_ids(self, attrs):
+        if len(attrs) == 0:
+            raise serializers.ValidationError("At least one category is required")
+        return attrs
 
     def _handle_relations(
         self, instance, related_product_types, categories, tags, conditions

--- a/src/open_producten/producttypes/serializers/producttype.py
+++ b/src/open_producten/producttypes/serializers/producttype.py
@@ -70,10 +70,10 @@ class ProductTypeSerializer(serializers.ModelSerializer):
         model = ProductType
         fields = "__all__"
 
-    def validate_category_ids(self, attrs):
-        if len(attrs) == 0:
+    def validate_category_ids(self, category_ids):
+        if len(category_ids) == 0:
             raise serializers.ValidationError("At least one category is required")
-        return attrs
+        return category_ids
 
     def _handle_relations(
         self, instance, related_product_types, categories, tags, conditions

--- a/src/open_producten/producttypes/tests/api/test_producttype.py
+++ b/src/open_producten/producttypes/tests/api/test_producttype.py
@@ -45,12 +45,14 @@ class TestProducttypeViewSet(BaseApiTestCase):
 
     def setUp(self):
         upn = UniformProductNameFactory.create()
+        category = CategoryFactory()
 
         self.data = {
             "name": "test-product-type",
             "summary": "test",
             "content": "test test",
             "uniform_product_name_id": upn.id,
+            "category_ids": [category.id],
         }
 
         self.path = "/api/v1/producttypes/"
@@ -60,6 +62,13 @@ class TestProducttypeViewSet(BaseApiTestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(ProductType.objects.count(), 1)
+
+    def test_create_product_type_without_fields_returns_error(self):
+        data = self.data.copy()
+        data["category_ids"] = []
+        response = self.post(data)
+
+        self.assertEqual(response.status_code, 400)
 
     def test_create_product_type_with_related_type(self):
         product_type = ProductTypeFactory.create()

--- a/src/open_producten/producttypes/tests/test_category_admin.py
+++ b/src/open_producten/producttypes/tests/test_category_admin.py
@@ -22,12 +22,12 @@ class TestCategoryAdminForm(TestCase):
         self.data = {
             "name": "test",
             "_position": "first-child",
-            "path": "0005",
+            "path": "00010001",
             "numchild": 1,
             "depth": 1,
         }
 
-    def test_parent_nodes_must_be_published(self):
+    def test_parent_nodes_must_be_published_when_publishing_child(self):
         parent = CategoryFactory.create(published=False)
         data = self.data | {"published": True, "_ref_node_id": parent.id}
 
@@ -47,7 +47,7 @@ class TestCategoryAdminForm(TestCase):
     def test_parent_nodes_cannot_be_unpublished_with_published_children(self):
         parent = CategoryFactory.create(published=False)
         parent.add_child(**{"name": "child", "published": True})
-        data = self.data | {"published": False, "_ref_node_id": None}
+        data = {"published": False, "_ref_node_id": None}
 
         form = create_form(data, parent)
 
@@ -66,7 +66,7 @@ class TestCategoryAdminFormSet(TestCase):
             fields=CategoryAdmin.list_editable,
         )
 
-        self.parent = CategoryFactory.create(published=True)
+        self.parent = Category.add_root(**{"name": "parent", "published": False})
         self.child = self.parent.add_child(**{"name": "child", "published": True})
 
     def test_parent_nodes_cannot_be_unpublished_with_published_children(self):


### PR DESCRIPTION
Adds custom validation to the api serializers.

### Field
- choice fields need choices
- normal fields cannot have choices
- added validate method to serializer that calls Field.clean()

### Product type
- needs at least one category
- added validate_category_ids to serializer

### category
- moved CategoryAdminForm clean method to model
- kept CategoryAdminFormSet clean as i could not get it working without
- added Category.clean call to serializer create and update because the validation needs to happen after the parent category is set/updated. 