### PR TITLE
Feature/10 products api

### DIFF
--- a/src/open_producten/conf/base.py
+++ b/src/open_producten/conf/base.py
@@ -66,6 +66,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PARSER_CLASSES": [
         "rest_framework.parsers.JSONParser",
     ],
+    "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
 }
 
 #

--- a/src/open_producten/products/admin/data.py
+++ b/src/open_producten/products/admin/data.py
@@ -16,7 +16,7 @@ class DataInlineFormSet(BaseInlineFormSet):
             return
 
         product_type = ProductType.objects.get(pk=self.data["product_type"])
-        required_fields = list(product_type.fields.filter(is_required=True).all())
+        required_fields = list(product_type.fields.filter(is_required=True))
 
         for form in self.forms:
 

--- a/src/open_producten/products/router.py
+++ b/src/open_producten/products/router.py
@@ -1,0 +1,12 @@
+from django.urls import include, path
+
+from rest_framework_nested.routers import DefaultRouter
+
+from open_producten.products.views import ProductViewSet
+
+ProductRouter = DefaultRouter()
+ProductRouter.register("products", ProductViewSet, basename="product")
+
+product_urlpatterns = [
+    path("", include(ProductRouter.urls)),
+]

--- a/src/open_producten/products/serializers/product.py
+++ b/src/open_producten/products/serializers/product.py
@@ -1,0 +1,137 @@
+from django.core.exceptions import ValidationError
+from rest_framework import serializers
+
+from open_producten.products.models import Data, Product
+from open_producten.producttypes.models import Field, ProductType
+from open_producten.producttypes.serializers.children import FieldSerializer
+from open_producten.producttypes.serializers.producttype import (
+    UniformProductNameSerializer,
+)
+
+
+class DataSerializer(serializers.ModelSerializer):
+    field = FieldSerializer(read_only=True)
+    field_id = serializers.PrimaryKeyRelatedField(
+        write_only=True, queryset=Field.objects.all(), source="field"
+    )
+    product = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Data
+        fields = "__all__"
+
+
+class SimpleProductTypeSerializer(serializers.ModelSerializer):
+    uniform_product_name = UniformProductNameSerializer()
+
+    class Meta:
+        model = ProductType
+        fields = "__all__"
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    product_type = SimpleProductTypeSerializer(read_only=True)
+    product_type_id = serializers.PrimaryKeyRelatedField(
+        write_only=True, queryset=ProductType.objects.all(), source="product_type"
+    )
+    data = DataSerializer(many=True)
+
+    class Meta:
+        model = Product
+        fields = "__all__"
+
+    def _validate_product(self, product, errors):
+        try:
+            product.clean()
+        except ValidationError:
+            errors.append("")
+
+    def create(self, validated_data):
+        data = validated_data.pop("data")
+
+        product = Product.objects.create(**validated_data)
+
+        product_type = product.product_type
+
+        required_fields = list(product_type.fields.filter(is_required=True).all())
+        data_errors = []
+        for idx, entry in enumerate(data):
+            field = entry["field"]
+            if field.product_type != product.product_type:
+                data_errors.append(
+                    f"field {field.name} is not part of {product_type.name}"
+                )
+            elif field in required_fields:
+                required_fields.remove(field)
+
+            data_entry = Data(product=product, **entry)
+            try:
+                data_entry.clean()
+            except ValidationError as e:
+                data_errors.append(f"Data at index {idx}: {e}")
+            data_entry.save()
+
+        if required_fields:
+            data_errors.append(
+                f"Missing required fields: {', '.join([str(field) for field in required_fields])}"
+            )
+
+        if data_errors:
+            raise serializers.ValidationError({"data": data_errors})
+        elif not product.bsn and not product.kvk:  # TODO
+            raise serializers.ValidationError(
+                "A product must be linked to a bsn or kvk number (or both)"
+            )
+
+        return product
+
+    def update(self, instance, validated_data):
+        data = validated_data.pop("data", None)
+        product = super().update(instance, validated_data)
+        data_errors = []
+
+        if data is not None:
+            current_data_ids = set(instance.data.values_list("id", flat=True))
+            seen_data_ids = set()
+            for idx, data_entry in enumerate(data):
+                data_id = data_entry.pop("id", None)
+
+                if data_id is None:
+                    data_entry = Data(product=product, **data_entry)
+
+                    try:
+                        data_entry.clean()
+                    except ValidationError as e:
+                        data_errors.append(f"Data id {data_id} at index {idx}: {e}")
+                    data_entry.save()
+
+                elif data_id in current_data_ids:
+
+                    if data_id in seen_data_ids:
+                        data_errors.append(
+                            f"Duplicate data id: {data_id} at index {idx}"
+                        )
+
+                    seen_data_ids.add(data_id)
+
+                else:
+                    try:
+                        Data.objects.get(id=data_id)
+                        data_errors.append(
+                            f"Data id {data_id} at index {idx} is not part of product object"
+                        )
+                    except Data.DoesNotExist:
+                        data_errors.append(
+                            f"Data id {data_id} at index {idx} does not exist"
+                        )
+
+            if data_errors:
+                raise serializers.ValidationError({"data": data_errors})
+            elif not product.bsn and not product.kvk:  # TODO
+                raise serializers.ValidationError(
+                    "A product must be linked to a bsn or kvk number (or both)"
+                )
+
+            Data.objects.filter(id__in=(current_data_ids - seen_data_ids)).delete()
+
+        return product

--- a/src/open_producten/products/serializers/product.py
+++ b/src/open_producten/products/serializers/product.py
@@ -7,7 +7,7 @@ from open_producten.products.models import Data, Product
 from open_producten.producttypes.models import Field, ProductType
 from open_producten.producttypes.serializers.category import SimpleProductTypeSerializer
 from open_producten.producttypes.serializers.children import FieldSerializer
-from open_producten.utils.serializers import model_to_dict_with_ids
+from open_producten.utils.serializers import model_to_dict_with_related_ids
 
 
 class DataSerializer(serializers.ModelSerializer):
@@ -27,7 +27,7 @@ class BaseProductSerializer(serializers.ModelSerializer):
         without_data.pop("data", None)
 
         if self.partial:
-            all_attrs = model_to_dict_with_ids(self.instance) | without_data
+            all_attrs = model_to_dict_with_related_ids(self.instance) | without_data
         else:
             all_attrs = without_data
 

--- a/src/open_producten/products/serializers/product.py
+++ b/src/open_producten/products/serializers/product.py
@@ -105,9 +105,7 @@ class ProductUpdateSerializer(BaseProductSerializer):
         if data is not None:
             data_errors = []
 
-            current_data_ids = set(
-                instance.data.values_list("id", flat=True).distinct()
-            )
+            current_data_ids = instance.data.values_list("id", flat=True).distinct()
 
             seen_data_ids = set()
             for idx, data_entry in enumerate(data):

--- a/src/open_producten/products/serializers/product.py
+++ b/src/open_producten/products/serializers/product.py
@@ -54,7 +54,7 @@ class ProductSerializer(BaseProductSerializer):
         product = Product.objects.create(**validated_data)
         product_type = product.product_type
 
-        required_fields = list(product_type.fields.filter(is_required=True).all())
+        required_fields = list(product_type.fields.filter(is_required=True))
         data_errors = []
         for idx, entry in enumerate(data):
             field = entry["field"]
@@ -105,7 +105,9 @@ class ProductUpdateSerializer(BaseProductSerializer):
         if data is not None:
             data_errors = []
 
-            current_data_ids = set(instance.data.values_list("id", flat=True))
+            current_data_ids = set(
+                instance.data.values_list("id", flat=True).distinct()
+            )
 
             seen_data_ids = set()
             for idx, data_entry in enumerate(data):

--- a/src/open_producten/products/tests/api/test_product.py
+++ b/src/open_producten/products/tests/api/test_product.py
@@ -1,30 +1,48 @@
 import datetime
+import uuid
 
 from django.forms import model_to_dict
+
 from freezegun import freeze_time
 from rest_framework.exceptions import ErrorDetail
 
-from open_producten.products.models import Product, Data
-from open_producten.products.tests.factories import ProductFactory
-from open_producten.producttypes.models import FieldTypes
-from open_producten.producttypes.tests.factories import ProductTypeFactory, FieldFactory
+from open_producten.products.models import Data, Product
+from open_producten.products.tests.factories import DataFactory, ProductFactory
+from open_producten.producttypes.models import Field, FieldTypes
+from open_producten.producttypes.tests.factories import FieldFactory, ProductTypeFactory
 from open_producten.utils.tests.cases import BaseApiTestCase
 
 
 def product_to_dict(product):
-    product_dict = model_to_dict(product, exclude=["product_type"]) | {"id": str(product.id)}
+    product_dict = model_to_dict(product) | {"id": str(product.id)}
     product_dict["start_date"] = str(product_dict["start_date"])
-    product_dict["data"] = [model_to_dict(data) for data in product.data.all()]
+    product_dict["data"] = [
+        model_to_dict(data, exclude=["product"])
+        | {
+            "id": str(data.id),
+            "field": model_to_dict(data.field, exclude=["product_type"])
+            | {"id": str(data.field.id)},
+        }
+        for data in product.data.all()
+    ]
     product_dict["end_date"] = str(product_dict["end_date"])
     product_dict["created_on"] = str(product.created_on.astimezone().isoformat())
     product_dict["updated_on"] = str(product.updated_on.astimezone().isoformat())
 
-    product_dict["product_type"] = model_to_dict(product.product_type) | {"id": str(product.product_type.id)}
-    product_dict["product_type"]["uniform_product_name"] = model_to_dict(product.product_type.uniform_product_name) | {
-        "id": str(product.product_type.uniform_product_name.id)}
+    product_dict["product_type"] = model_to_dict(
+        product.product_type,
+        exclude=("categories", "conditions", "tags", "related_product_types"),
+    ) | {"id": str(product.product_type.id)}
+    product_dict["product_type"]["uniform_product_name"] = model_to_dict(
+        product.product_type.uniform_product_name
+    ) | {"id": str(product.product_type.uniform_product_name.id)}
 
-    product_dict["product_type"]["created_on"] = str(product.product_type.created_on.astimezone().isoformat())
-    product_dict["product_type"]["updated_on"] = str(product.product_type.updated_on.astimezone().isoformat())
+    product_dict["product_type"]["created_on"] = str(
+        product.product_type.created_on.astimezone().isoformat()
+    )
+    product_dict["product_type"]["updated_on"] = str(
+        product.product_type.updated_on.astimezone().isoformat()
+    )
     return product_dict
 
 
@@ -33,12 +51,17 @@ class TestProduct(BaseApiTestCase):
 
     def setUp(self):
         self.product_type = ProductTypeFactory.create()
-        self.data = {"product_type_id": self.product_type.id, "bsn": "111222333",
-                     "start_date": datetime.date(2024, 1, 2), "end_date": datetime.date(2024, 12, 31), "data": []}
+        self.data = {
+            "product_type_id": self.product_type.id,
+            "bsn": "111222333",
+            "start_date": datetime.date(2024, 1, 2),
+            "end_date": datetime.date(2024, 12, 31),
+            "data": [],
+        }
         self.path = "/api/v1/products/"
 
     def create_product(self):
-        return ProductFactory.create()
+        return ProductFactory.create(bsn="111222333")
 
     def test_create_product(self):
         response = self.post(self.data)
@@ -46,11 +69,19 @@ class TestProduct(BaseApiTestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Product.objects.count(), 1)
 
-    def test_create_product_without_required_fields_returns_error(self):
-        product_type = ProductTypeFactory.create()
-        FieldFactory.create(product_type=product_type, type=FieldTypes.TEXTFIELD, is_required=True)
+    def test_create_product_without_bsn_or_kvk_returns_error(self):
+        data = self.data.copy()
+        data.pop("bsn")
 
-        data = self.data | {"product_type_id": product_type.id}
+        response = self.post(data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_product_without_required_fields_returns_error(self):
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=True
+        )
+
+        data = self.data | {"product_type_id": self.product_type.id}
 
         response = self.post(data)
 
@@ -60,62 +91,69 @@ class TestProduct(BaseApiTestCase):
             {
                 "data": [
                     ErrorDetail(
-                        string="Missing required fields: field 0",
+                        string=f"Missing required fields: {field.name}",
                         code="invalid",
                     )
                 ]
             },
         )
+        self.assertEqual(Product.objects.count(), 0)
 
-    def test_create_product_without_non_required_fields_returns_error(self):
-        product_type = ProductTypeFactory.create()
-        FieldFactory.create(product_type=product_type, type=FieldTypes.TEXTFIELD, is_required=False)
+    def test_create_product_without_non_required_fields(self):
+        FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=False
+        )
 
-        data = self.data | {"product_type_id": product_type.id}
-
-        response = self.post(data)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(Product.objects.count(), 1)
-
-    def test_create_product_with_data_for_required_field_returns_error(self):
-        product_type = ProductTypeFactory.create()
-        field = FieldFactory.create(product_type=product_type, type=FieldTypes.TEXTFIELD, is_required=True)
-
-        data = self.data | {"product_type_id": product_type.id, "data": [{
-            "field_id": field.id,
-            "value": "abc"
-        }]}
+        data = self.data | {"product_type_id": self.product_type.id}
 
         response = self.post(data)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Product.objects.count(), 1)
+
+    def test_create_product_with_data_for_required_field(self):
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=True
+        )
+
+        data = self.data | {
+            "product_type_id": self.product_type.id,
+            "data": [{"field_id": field.id, "value": "abc"}],
+        }
+
+        response = self.post(data)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Field.objects.count(), 1)
         self.assertEqual(Data.objects.count(), 1)
 
     def test_create_product_with_data_for_unrequired_field_returns_error(self):
-        product_type = ProductTypeFactory.create()
-        field = FieldFactory.create(product_type=product_type, type=FieldTypes.TEXTFIELD, is_required=False)
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=False
+        )
 
-        data = self.data | {"product_type_id": product_type.id, "data": [{
-            "field_id": field.id,
-            "value": "abc"
-        }]}
+        data = self.data | {
+            "product_type_id": self.product_type.id,
+            "data": [{"field_id": field.id, "value": "abc"}],
+        }
 
         response = self.post(data)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Field.objects.count(), 1)
         self.assertEqual(Data.objects.count(), 1)
 
     def test_create_product_with_wrong_data_for_field_returns_error(self):
-        product_type = ProductTypeFactory.create()
-        field = FieldFactory.create(product_type=product_type, type=FieldTypes.NUMBER, is_required=True)
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.NUMBER, is_required=True
+        )
 
-        data = self.data | {"product_type_id": product_type.id, "data": [{
-            "field_id": field.id,
-            "value": "abc"
-        }]}
+        data = self.data | {
+            "product_type_id": self.product_type.id,
+            "data": [{"field_id": field.id, "value": "abc"}],
+        }
 
         response = self.post(data)
 
@@ -125,21 +163,24 @@ class TestProduct(BaseApiTestCase):
             {
                 "data": [
                     ErrorDetail(
-                        string="Data at index 0: ['invalid number']",  # TODO
+                        string="Data at index 0: ['invalid number']",
                         code="invalid",
                     )
                 ]
             },
         )
+        self.assertEqual(Product.objects.count(), 0)
+        self.assertEqual(Data.objects.count(), 0)
 
-    def test_create_product_with_data_for_field_not_part_of_product_type_returns_error(self):
-        product_type = ProductTypeFactory.create()
+    def test_create_product_with_data_for_field_not_part_of_product_type_returns_error(
+        self,
+    ):
         field = FieldFactory.create(type=FieldTypes.TEXTFIELD, is_required=True)
 
-        data = self.data | {"product_type_id": product_type.id, "data": [{
-            "field_id": field.id,
-            "value": "abc"
-        }]}
+        data = self.data | {
+            "product_type_id": self.product_type.id,
+            "data": [{"field_id": field.id, "value": "abc"}],
+        }
 
         response = self.post(data)
 
@@ -149,12 +190,15 @@ class TestProduct(BaseApiTestCase):
             {
                 "data": [
                     ErrorDetail(
-                        string="field field 0 is not part of product type 2",  # TODO
+                        string=f"field {field.name} is not part of {self.product_type.name}",
                         code="invalid",
                     )
                 ]
             },
         )
+        self.assertEqual(Product.objects.count(), 0)
+        self.assertEqual(Data.objects.count(), 0)
+        self.assertEqual(Field.objects.count(), 1)
 
     def test_update_product(self):
         product = self.create_product()
@@ -165,6 +209,149 @@ class TestProduct(BaseApiTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Product.objects.count(), 1)
 
+    def test_update_product_without_bsn_or_kvk(self):
+        product = self.create_product()
+
+        data = self.data.copy()
+        data.pop("bsn")
+        response = self.put(product.id, data)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_product_data(self):
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=True
+        )
+        product = self.create_product()
+        data_instance = DataFactory.create(product=product, field=field, value="abc")
+
+        data = self.data | {"data": [{"id": data_instance.id, "value": "123"}]}
+
+        response = self.put(product.id, data)
+        data_instance.refresh_from_db()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Data.objects.count(), 1)
+        self.assertEqual(data_instance.value, "123")
+
+    def test_update_product_with_duplicate_data_ids_returns_error(self):
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=True
+        )
+        product = self.create_product()
+        data_instance = DataFactory.create(product=product, field=field, value="abc")
+
+        data = self.data | {
+            "data": [
+                {"id": data_instance.id, "value": "123"},
+                {"id": data_instance.id, "value": "123"},
+            ]
+        }
+
+        response = self.put(product.id, data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "data": [
+                    ErrorDetail(
+                        string=f"Duplicate data id: {data_instance.id} at index 1",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+    def test_update_product_with_data_not_part_of_product_returns_error(
+        self,
+    ):
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=True
+        )
+        product = self.create_product()
+        data_instance = DataFactory.create(
+            product=self.create_product(), field=field, value="abc"
+        )
+
+        data = self.data | {
+            "product_type_id": self.product_type.id,
+            "data": [{"id": data_instance.id, "value": "abc"}],
+        }
+
+        response = self.put(product.id, data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "data": [
+                    ErrorDetail(
+                        string=f"Data id {data_instance.id} at index 0 is not part of product object",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+    def test_update_product_with_no_existing_data_object_returns_error(
+        self,
+    ):
+        FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=True
+        )
+        product = self.create_product()
+
+        dummy_id = uuid.uuid4()
+
+        data = self.data | {
+            "product_type_id": self.product_type.id,
+            "data": [{"id": dummy_id, "value": "abc"}],
+        }
+
+        response = self.put(product.id, data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "data": [
+                    ErrorDetail(
+                        string=f"Data id {dummy_id} at index 0 does not exist",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+    def test_update_product_with_invalid_data_returns_error(self):
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.NUMBER, is_required=True
+        )
+        product = self.create_product()
+        data_instance = DataFactory.create(product=product, field=field, value="123")
+
+        data = self.data | {
+            "product_type_id": self.product_type.id,
+            "data": [{"id": data_instance.id, "value": "abc"}],
+        }
+
+        response = self.put(product.id, data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "data": [
+                    ErrorDetail(
+                        string="Data at index 0: ['invalid number']",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
     def test_partial_update_product(self):
         product = self.create_product()
 
@@ -173,6 +360,23 @@ class TestProduct(BaseApiTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Product.objects.count(), 1)
+
+    def test_partial_update_product_data(self):
+        field = FieldFactory.create(
+            product_type=self.product_type, type=FieldTypes.TEXTFIELD, is_required=True
+        )
+        product = self.create_product()
+        data_instance = DataFactory.create(product=product, field=field, value="abc")
+
+        data = {"data": [{"id": data_instance.id, "value": "123"}]}
+
+        response = self.patch(product.id, data)
+        data_instance.refresh_from_db()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Data.objects.count(), 1)
+        self.assertEqual(data_instance.value, "123")
 
     def test_read_products(self):
         product = self.create_product()
@@ -190,6 +394,14 @@ class TestProduct(BaseApiTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, product_to_dict(product))
 
+    def test_read_product_with_data(self):
+        product = self.create_product()
+        field = FieldFactory.create(
+            product_type=self.product_type, is_required=True, type="textfield"
+        )
+        DataFactory.create(product=product, field=field, value="abc")
+        response = self.get(product.id)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, product_to_dict(product))
 
     def test_delete_product(self):

--- a/src/open_producten/products/tests/api/test_product.py
+++ b/src/open_producten/products/tests/api/test_product.py
@@ -1,0 +1,200 @@
+import datetime
+
+from django.forms import model_to_dict
+from freezegun import freeze_time
+from rest_framework.exceptions import ErrorDetail
+
+from open_producten.products.models import Product, Data
+from open_producten.products.tests.factories import ProductFactory
+from open_producten.producttypes.models import FieldTypes
+from open_producten.producttypes.tests.factories import ProductTypeFactory, FieldFactory
+from open_producten.utils.tests.cases import BaseApiTestCase
+
+
+def product_to_dict(product):
+    product_dict = model_to_dict(product, exclude=["product_type"]) | {"id": str(product.id)}
+    product_dict["start_date"] = str(product_dict["start_date"])
+    product_dict["data"] = [model_to_dict(data) for data in product.data.all()]
+    product_dict["end_date"] = str(product_dict["end_date"])
+    product_dict["created_on"] = str(product.created_on.astimezone().isoformat())
+    product_dict["updated_on"] = str(product.updated_on.astimezone().isoformat())
+
+    product_dict["product_type"] = model_to_dict(product.product_type) | {"id": str(product.product_type.id)}
+    product_dict["product_type"]["uniform_product_name"] = model_to_dict(product.product_type.uniform_product_name) | {
+        "id": str(product.product_type.uniform_product_name.id)}
+
+    product_dict["product_type"]["created_on"] = str(product.product_type.created_on.astimezone().isoformat())
+    product_dict["product_type"]["updated_on"] = str(product.product_type.updated_on.astimezone().isoformat())
+    return product_dict
+
+
+@freeze_time("2024-01-01")
+class TestProduct(BaseApiTestCase):
+
+    def setUp(self):
+        self.product_type = ProductTypeFactory.create()
+        self.data = {"product_type_id": self.product_type.id, "bsn": "111222333",
+                     "start_date": datetime.date(2024, 1, 2), "end_date": datetime.date(2024, 12, 31), "data": []}
+        self.path = "/api/v1/products/"
+
+    def create_product(self):
+        return ProductFactory.create()
+
+    def test_create_product(self):
+        response = self.post(self.data)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Product.objects.count(), 1)
+
+    def test_create_product_without_required_fields_returns_error(self):
+        product_type = ProductTypeFactory.create()
+        FieldFactory.create(product_type=product_type, type=FieldTypes.TEXTFIELD, is_required=True)
+
+        data = self.data | {"product_type_id": product_type.id}
+
+        response = self.post(data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "data": [
+                    ErrorDetail(
+                        string="Missing required fields: field 0",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+    def test_create_product_without_non_required_fields_returns_error(self):
+        product_type = ProductTypeFactory.create()
+        FieldFactory.create(product_type=product_type, type=FieldTypes.TEXTFIELD, is_required=False)
+
+        data = self.data | {"product_type_id": product_type.id}
+
+        response = self.post(data)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Product.objects.count(), 1)
+
+    def test_create_product_with_data_for_required_field_returns_error(self):
+        product_type = ProductTypeFactory.create()
+        field = FieldFactory.create(product_type=product_type, type=FieldTypes.TEXTFIELD, is_required=True)
+
+        data = self.data | {"product_type_id": product_type.id, "data": [{
+            "field_id": field.id,
+            "value": "abc"
+        }]}
+
+        response = self.post(data)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Data.objects.count(), 1)
+
+    def test_create_product_with_data_for_unrequired_field_returns_error(self):
+        product_type = ProductTypeFactory.create()
+        field = FieldFactory.create(product_type=product_type, type=FieldTypes.TEXTFIELD, is_required=False)
+
+        data = self.data | {"product_type_id": product_type.id, "data": [{
+            "field_id": field.id,
+            "value": "abc"
+        }]}
+
+        response = self.post(data)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Data.objects.count(), 1)
+
+    def test_create_product_with_wrong_data_for_field_returns_error(self):
+        product_type = ProductTypeFactory.create()
+        field = FieldFactory.create(product_type=product_type, type=FieldTypes.NUMBER, is_required=True)
+
+        data = self.data | {"product_type_id": product_type.id, "data": [{
+            "field_id": field.id,
+            "value": "abc"
+        }]}
+
+        response = self.post(data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "data": [
+                    ErrorDetail(
+                        string="Data at index 0: ['invalid number']",  # TODO
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+    def test_create_product_with_data_for_field_not_part_of_product_type_returns_error(self):
+        product_type = ProductTypeFactory.create()
+        field = FieldFactory.create(type=FieldTypes.TEXTFIELD, is_required=True)
+
+        data = self.data | {"product_type_id": product_type.id, "data": [{
+            "field_id": field.id,
+            "value": "abc"
+        }]}
+
+        response = self.post(data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "data": [
+                    ErrorDetail(
+                        string="field field 0 is not part of product type 2",  # TODO
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+
+    def test_update_product(self):
+        product = self.create_product()
+
+        data = self.data | {"end_date": datetime.date(2025, 12, 31)}
+        response = self.put(product.id, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Product.objects.count(), 1)
+
+    def test_partial_update_product(self):
+        product = self.create_product()
+
+        data = {"end_date": datetime.date(2025, 12, 31)}
+        response = self.patch(product.id, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Product.objects.count(), 1)
+
+    def test_read_products(self):
+        product = self.create_product()
+
+        response = self.get()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [product_to_dict(product)])
+
+    def test_read_product(self):
+        product = self.create_product()
+
+        response = self.get(product.id)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, product_to_dict(product))
+
+        self.assertEqual(response.data, product_to_dict(product))
+
+    def test_delete_product(self):
+        product = self.create_product()
+        response = self.delete(product.id)
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(Product.objects.count(), 0)

--- a/src/open_producten/products/tests/api/test_product.py
+++ b/src/open_producten/products/tests/api/test_product.py
@@ -1,8 +1,6 @@
 import datetime
 import uuid
 
-from django.forms import model_to_dict
-
 from freezegun import freeze_time
 from rest_framework.exceptions import ErrorDetail
 
@@ -11,31 +9,28 @@ from open_producten.products.tests.factories import DataFactory, ProductFactory
 from open_producten.producttypes.models import Field, FieldTypes
 from open_producten.producttypes.tests.factories import FieldFactory, ProductTypeFactory
 from open_producten.utils.tests.cases import BaseApiTestCase
+from open_producten.utils.tests.helpers import model_to_dict_with_id
 
 
 def product_to_dict(product):
-    product_dict = model_to_dict(product) | {"id": str(product.id)}
+    product_dict = model_to_dict_with_id(product)
     product_dict["start_date"] = str(product_dict["start_date"])
     product_dict["data"] = [
-        model_to_dict(data, exclude=["product"])
-        | {
-            "id": str(data.id),
-            "field": model_to_dict(data.field, exclude=["product_type"])
-            | {"id": str(data.field.id)},
-        }
+        model_to_dict_with_id(data, exclude=["product"])
+        | {"field": model_to_dict_with_id(data.field, exclude=["product_type"])}
         for data in product.data.all()
     ]
     product_dict["end_date"] = str(product_dict["end_date"])
     product_dict["created_on"] = str(product.created_on.astimezone().isoformat())
     product_dict["updated_on"] = str(product.updated_on.astimezone().isoformat())
 
-    product_dict["product_type"] = model_to_dict(
+    product_dict["product_type"] = model_to_dict_with_id(
         product.product_type,
         exclude=("categories", "conditions", "tags", "related_product_types"),
-    ) | {"id": str(product.product_type.id)}
-    product_dict["product_type"]["uniform_product_name"] = model_to_dict(
+    )
+    product_dict["product_type"]["uniform_product_name"] = model_to_dict_with_id(
         product.product_type.uniform_product_name
-    ) | {"id": str(product.product_type.uniform_product_name.id)}
+    )
 
     product_dict["product_type"]["created_on"] = str(
         product.product_type.created_on.astimezone().isoformat()

--- a/src/open_producten/products/tests/api/test_product.py
+++ b/src/open_producten/products/tests/api/test_product.py
@@ -38,6 +38,8 @@ def product_to_dict(product):
     product_dict["product_type"]["updated_on"] = str(
         product.product_type.updated_on.astimezone().isoformat()
     )
+    product_dict["product_type"]["icon"] = None
+    product_dict["product_type"]["image"] = None
     return product_dict
 
 
@@ -63,6 +65,8 @@ class TestProduct(BaseApiTestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Product.objects.count(), 1)
+        product = Product.objects.first()
+        self.assertEqual(response.data, product_to_dict(product))
 
     def test_create_product_without_bsn_or_kvk_returns_error(self):
         data = self.data.copy()
@@ -70,6 +74,18 @@ class TestProduct(BaseApiTestCase):
 
         response = self.post(data)
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="A product must be linked to a bsn or kvk number (or both)",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
+        self.assertEqual(Product.objects.count(), 0)
 
     def test_create_product_without_required_fields_returns_error(self):
         field = FieldFactory.create(
@@ -212,6 +228,17 @@ class TestProduct(BaseApiTestCase):
         response = self.put(product.id, data)
 
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data,
+            {
+                "non_field_errors": [
+                    ErrorDetail(
+                        string="A product must be linked to a bsn or kvk number (or both)",
+                        code="invalid",
+                    )
+                ]
+            },
+        )
 
     def test_update_product_data(self):
         field = FieldFactory.create(

--- a/src/open_producten/products/views.py
+++ b/src/open_producten/products/views.py
@@ -1,0 +1,10 @@
+from rest_framework.viewsets import ModelViewSet
+
+from open_producten.products.models import Product
+from open_producten.products.serializers.product import ProductSerializer
+
+
+class ProductViewSet(ModelViewSet):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer
+    lookup_url_field = "id"

--- a/src/open_producten/products/views.py
+++ b/src/open_producten/products/views.py
@@ -1,10 +1,17 @@
 from rest_framework.viewsets import ModelViewSet
 
 from open_producten.products.models import Product
-from open_producten.products.serializers.product import ProductSerializer
+from open_producten.products.serializers.product import (
+    ProductSerializer,
+    ProductUpdateSerializer,
+)
 
 
 class ProductViewSet(ModelViewSet):
     queryset = Product.objects.all()
-    serializer_class = ProductSerializer
     lookup_url_field = "id"
+
+    def get_serializer_class(self):
+        if self.action in ("update", "partial_update"):
+            return ProductUpdateSerializer
+        return ProductSerializer

--- a/src/open_producten/producttypes/serializers/children.py
+++ b/src/open_producten/producttypes/serializers/children.py
@@ -2,7 +2,7 @@ from django.db import transaction
 
 from rest_framework import serializers
 
-from open_producten.utils.serializers import model_to_dict_with_ids
+from open_producten.utils.serializers import model_to_dict_with_related_ids
 
 from ..models import (
     Condition,
@@ -100,7 +100,7 @@ class FieldSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         if self.partial:
-            all_attrs = model_to_dict_with_ids(self.instance) | attrs
+            all_attrs = model_to_dict_with_related_ids(self.instance) | attrs
         else:
             all_attrs = attrs
 

--- a/src/open_producten/producttypes/serializers/children.py
+++ b/src/open_producten/producttypes/serializers/children.py
@@ -2,6 +2,8 @@ from django.db import transaction
 
 from rest_framework import serializers
 
+from open_producten.utils.serializers import model_to_dict_with_ids
+
 from ..models import (
     Condition,
     Field,
@@ -97,7 +99,12 @@ class FieldSerializer(serializers.ModelSerializer):
         exclude = ("product_type",)
 
     def validate(self, attrs):
-        instance = Field(**attrs)
+        if self.partial:
+            all_attrs = model_to_dict_with_ids(self.instance) | attrs
+        else:
+            all_attrs = attrs
+
+        instance = Field(**all_attrs)
         instance.clean()
         return attrs
 

--- a/src/open_producten/producttypes/serializers/children.py
+++ b/src/open_producten/producttypes/serializers/children.py
@@ -52,7 +52,9 @@ class PriceSerializer(serializers.ModelSerializer):
         option_errors = []
 
         if options is not None:
-            current_option_ids = set(price.options.values_list("id", flat=True))
+            current_option_ids = set(
+                price.options.values_list("id", flat=True).distinct()
+            )
             seen_option_ids = set()
             for idx, option in enumerate(options):
                 option_id = option.pop("id", None)
@@ -112,7 +114,7 @@ class FieldSerializer(serializers.ModelSerializer):
 class FileSerializer(serializers.ModelSerializer):
     class Meta:
         model = File
-        exclude = ("id", "product_type")
+        exclude = ("product_type",)
 
 
 class TagTypeSerializer(serializers.ModelSerializer):

--- a/src/open_producten/producttypes/serializers/producttype.py
+++ b/src/open_producten/producttypes/serializers/producttype.py
@@ -19,7 +19,7 @@ from .children import (
 class SimpleCategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = Category
-        exclude = ("id", "path", "depth", "numchild")
+        exclude = ("path", "depth", "numchild")
 
 
 class ProductTypeSerializer(serializers.ModelSerializer):

--- a/src/open_producten/producttypes/serializers/producttype.py
+++ b/src/open_producten/producttypes/serializers/producttype.py
@@ -8,6 +8,7 @@ from ..models import Category, Condition, ProductType, Tag, UniformProductName
 from .children import (
     ConditionSerializer,
     FieldSerializer,
+    FileSerializer,
     LinkSerializer,
     PriceSerializer,
     QuestionSerializer,
@@ -65,6 +66,7 @@ class ProductTypeSerializer(serializers.ModelSerializer):
     fields = FieldSerializer(many=True, read_only=True)
     prices = PriceSerializer(many=True, read_only=True)
     links = LinkSerializer(many=True, read_only=True)
+    files = FileSerializer(many=True, read_only=True)
 
     class Meta:
         model = ProductType

--- a/src/open_producten/producttypes/tests/api/test_category.py
+++ b/src/open_producten/producttypes/tests/api/test_category.py
@@ -26,6 +26,9 @@ def category_to_dict(category):
     category_dict["parent_category"] = (
         category.parent_category.id if category.parent_category else None
     )
+
+    category_dict["icon"] = None
+    category_dict["image"] = None
     return category_dict
 
 
@@ -52,9 +55,10 @@ class TestCategoryViewSet(BaseApiTestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Category.objects.count(), 2)
-        self.assertEqual(
-            Category.objects.get(id=response.data["id"]).get_parent(), parent
-        )
+
+        category = Category.objects.get(id=response.data["id"])
+        self.assertEqual(category.get_parent(), parent)
+        self.assertEqual(response.data, category_to_dict(category))
 
     def test_create_category_with_product_type(self):
         product_type = ProductTypeFactory.create()

--- a/src/open_producten/producttypes/tests/api/test_condition.py
+++ b/src/open_producten/producttypes/tests/api/test_condition.py
@@ -1,14 +1,12 @@
-from django.forms import model_to_dict
-
 from open_producten.producttypes.models import Condition
 from open_producten.utils.tests.cases import BaseApiTestCase
+from open_producten.utils.tests.helpers import model_to_dict_with_id
 
 from ..factories import ConditionFactory
 
 
 def condition_to_dict(condition):
-    condition_dict = model_to_dict(condition) | {"id": str(condition.id)}
-    return condition_dict
+    return model_to_dict_with_id(condition)
 
 
 class TestProductTypeCondition(BaseApiTestCase):

--- a/src/open_producten/producttypes/tests/api/test_product_type_field.py
+++ b/src/open_producten/producttypes/tests/api/test_product_type_field.py
@@ -1,14 +1,13 @@
-from django.forms import model_to_dict
-
 from rest_framework.exceptions import ErrorDetail
 
 from open_producten.producttypes.models import Field, ProductType
 from open_producten.producttypes.tests.factories import FieldFactory, ProductTypeFactory
 from open_producten.utils.tests.cases import BaseApiTestCase
+from open_producten.utils.tests.helpers import model_to_dict_with_id
 
 
 def field_to_dict(field):
-    return model_to_dict(field, exclude=["product_type"]) | {"id": str(field.id)}
+    return model_to_dict_with_id(field, exclude=["product_type"])
 
 
 class TestProductTypeField(BaseApiTestCase):

--- a/src/open_producten/producttypes/tests/api/test_product_type_field.py
+++ b/src/open_producten/producttypes/tests/api/test_product_type_field.py
@@ -76,6 +76,18 @@ class TestProductTypeField(BaseApiTestCase):
         self.assertEqual(Field.objects.count(), 1)
         self.assertEqual(ProductType.objects.first().fields.first().name, "updated")
 
+    def test_partial_update_change_choices(self):
+        field = FieldFactory.create(
+            product_type=self.product_type, type="select", choices=["a", "b"]
+        )
+
+        data = {"choices": ["a"]}
+        response = self.patch(field.id, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Field.objects.count(), 1)
+        self.assertEqual(ProductType.objects.first().fields.first().choices, ["a"])
+
     def test_read_fields(self):
         field = self.create_field()
 

--- a/src/open_producten/producttypes/tests/api/test_product_type_link.py
+++ b/src/open_producten/producttypes/tests/api/test_product_type_link.py
@@ -1,13 +1,12 @@
-from django.forms import model_to_dict
-
 from open_producten.producttypes.models import Link, ProductType
 from open_producten.utils.tests.cases import BaseApiTestCase
+from open_producten.utils.tests.helpers import model_to_dict_with_id
 
 from ..factories import LinkFactory, ProductTypeFactory
 
 
 def link_to_dict(link):
-    return model_to_dict(link, exclude=["product_type"]) | {"id": str(link.id)}
+    return model_to_dict_with_id(link, exclude=["product_type"])
 
 
 class TestProductTypeLink(BaseApiTestCase):

--- a/src/open_producten/producttypes/tests/api/test_product_type_price.py
+++ b/src/open_producten/producttypes/tests/api/test_product_type_price.py
@@ -14,10 +14,11 @@ from open_producten.producttypes.tests.factories import (
     ProductTypeFactory,
 )
 from open_producten.utils.tests.cases import BaseApiTestCase
+from open_producten.utils.tests.helpers import model_to_dict_with_id
 
 
 def price_to_dict(price):
-    price_dict = model_to_dict(price, exclude=["product_type"]) | {"id": str(price.id)}
+    price_dict = model_to_dict_with_id(price, exclude=["product_type"])
     price_dict["options"] = [model_to_dict(option) for option in price.options.all()]
     price_dict["valid_from"] = str(price_dict["valid_from"])
 

--- a/src/open_producten/producttypes/tests/api/test_producttype.py
+++ b/src/open_producten/producttypes/tests/api/test_producttype.py
@@ -12,10 +12,11 @@ from open_producten.producttypes.tests.factories import (
     UniformProductNameFactory,
 )
 from open_producten.utils.tests.cases import BaseApiTestCase
+from open_producten.utils.tests.helpers import model_to_dict_with_id
 
 
 def product_type_to_dict(product_type):
-    product_type_dict = model_to_dict(product_type) | {"id": str(product_type.id)}
+    product_type_dict = model_to_dict_with_id(product_type)
     product_type_dict["questions"] = [
         model_to_dict(question) for question in product_type.questions.all()
     ]
@@ -34,10 +35,9 @@ def product_type_to_dict(product_type):
     product_type_dict["updated_on"] = str(
         product_type.updated_on.astimezone().isoformat()
     )
-    product_type_dict["uniform_product_name"] = model_to_dict(
+    product_type_dict["uniform_product_name"] = model_to_dict_with_id(
         product_type.uniform_product_name
-    ) | {"id": str(product_type.uniform_product_name.id)}
-
+    )
     return product_type_dict
 
 

--- a/src/open_producten/producttypes/tests/api/test_tag.py
+++ b/src/open_producten/producttypes/tests/api/test_tag.py
@@ -1,14 +1,13 @@
-from django.forms import model_to_dict
-
 from open_producten.producttypes.models import Tag
 from open_producten.utils.tests.cases import BaseApiTestCase
+from open_producten.utils.tests.helpers import model_to_dict_with_id
 
 from ..factories import TagFactory, TagTypeFactory
 
 
 def tag_to_dict(tag):
-    tag_dict = model_to_dict(tag) | {"id": str(tag.id)}
-    tag_dict["type"] = model_to_dict(tag.type) | {"id": str(tag.type.id)}
+    tag_dict = model_to_dict_with_id(tag)
+    tag_dict["type"] = model_to_dict_with_id(tag.type)
     return tag_dict
 
 

--- a/src/open_producten/producttypes/tests/api/test_tag_type.py
+++ b/src/open_producten/producttypes/tests/api/test_tag_type.py
@@ -1,14 +1,12 @@
-from django.forms import model_to_dict
-
 from open_producten.producttypes.models import TagType
 from open_producten.utils.tests.cases import BaseApiTestCase
+from open_producten.utils.tests.helpers import model_to_dict_with_id
 
 from ..factories import TagTypeFactory
 
 
-def tag_type_to_dict(tag):
-    tag_dict = model_to_dict(tag) | {"id": str(tag.id)}
-    return tag_dict
+def tag_type_to_dict(tag_type):
+    return model_to_dict_with_id(tag_type)
 
 
 class TestProductTypeTagType(BaseApiTestCase):

--- a/src/open_producten/urls.py
+++ b/src/open_producten/urls.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
-from django.views.generic.base import TemplateView
+from django.views.generic.base import RedirectView
 
 from drf_spectacular.views import (
     SpectacularAPIView,
@@ -56,7 +56,7 @@ urlpatterns = [
         name="password_reset_complete",
     ),
     # Simply show the master template.
-    path("", TemplateView.as_view(template_name="master.html"), name="root"),
+    path("", RedirectView.as_view(pattern_name="admin:index")),
     path(
         "api/v1/",
         include(

--- a/src/open_producten/urls.py
+++ b/src/open_producten/urls.py
@@ -16,6 +16,7 @@ from maykin_2fa import monkeypatch_admin
 from maykin_2fa.urls import urlpatterns, webauthn_urlpatterns
 
 from open_producten.accounts.views.password_reset import PasswordResetView
+from open_producten.products.router import product_urlpatterns
 from open_producten.producttypes.router import product_type_urlpatterns
 
 # Configure admin
@@ -76,6 +77,7 @@ urlpatterns = [
                     name="redoc",
                 ),
                 path("", include(product_type_urlpatterns)),
+                path("", include(product_urlpatterns)),
             ]
         ),
     ),

--- a/src/open_producten/utils/serializers.py
+++ b/src/open_producten/utils/serializers.py
@@ -20,7 +20,8 @@ def build_array_duplicates_error_message(objects: list, field: str, errors):
         errors[field] = errors_messages
 
 
-def model_to_dict_with_ids(model: BaseModel) -> dict:
+def model_to_dict_with_related_ids(model: BaseModel) -> dict:
+    """Creates a dict from a model and appends UUID fields with '_id'"""
     model_dict = model_to_dict(model)
 
     for k, v in list(model_dict.items()):

--- a/src/open_producten/utils/serializers.py
+++ b/src/open_producten/utils/serializers.py
@@ -1,3 +1,10 @@
+from uuid import UUID
+
+from django.forms.models import model_to_dict
+
+from .models import BaseModel
+
+
 def build_array_duplicates_error_message(objects: list, field: str, errors):
     object_set = set()
     errors_messages = []
@@ -11,3 +18,13 @@ def build_array_duplicates_error_message(objects: list, field: str, errors):
 
     if errors_messages:
         errors[field] = errors_messages
+
+
+def model_to_dict_with_ids(model: BaseModel) -> dict:
+    model_dict = model_to_dict(model)
+
+    for k, v in list(model_dict.items()):
+        if isinstance(v, UUID):
+            model_dict[f"{k}_id"] = model_dict.pop(k)
+
+    return model_dict

--- a/src/open_producten/utils/tests/helpers.py
+++ b/src/open_producten/utils/tests/helpers.py
@@ -1,3 +1,8 @@
+from django.forms.models import model_to_dict
+
+from open_producten.utils.models import BaseModel
+
+
 def build_formset_data(form_name: str, *forms: dict, extra: dict | None = None):
     data = (extra if extra else {}) | {
         f"{form_name}-TOTAL_FORMS": len(forms),
@@ -9,3 +14,7 @@ def build_formset_data(form_name: str, *forms: dict, extra: dict | None = None):
             data[f"{form_name}-{i}-{key}"] = form[key]
 
     return data
+
+
+def model_to_dict_with_id(model: BaseModel, fields=None, exclude=None):
+    return model_to_dict(model, fields=fields, exclude=exclude) | {"id": str(model.id)}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -461,6 +461,145 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/v1/products/:
+    get:
+      operationId: products_list
+      tags:
+        - products
+      security:
+        - cookieAuth: [ ]
+        - basicAuth: [ ]
+        - { }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Product'
+          description: ''
+    post:
+      operationId: products_create
+      tags:
+        - products
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+        required: true
+      security:
+        - cookieAuth: [ ]
+        - basicAuth: [ ]
+        - { }
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+          description: ''
+  /api/v1/products/{id}/:
+    get:
+      operationId: products_retrieve
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          description: A UUID string identifying this Product.
+          required: true
+      tags:
+        - products
+      security:
+        - cookieAuth: [ ]
+        - basicAuth: [ ]
+        - { }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+          description: ''
+    put:
+      operationId: products_update
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          description: A UUID string identifying this Product.
+          required: true
+      tags:
+        - products
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductUpdate'
+        required: true
+      security:
+        - cookieAuth: [ ]
+        - basicAuth: [ ]
+        - { }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUpdate'
+          description: ''
+    patch:
+      operationId: products_partial_update
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          description: A UUID string identifying this Product.
+          required: true
+      tags:
+        - products
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedProductUpdate'
+      security:
+        - cookieAuth: [ ]
+        - basicAuth: [ ]
+        - { }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductUpdate'
+          description: ''
+    delete:
+      operationId: products_destroy
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          description: A UUID string identifying this Product.
+          required: true
+      tags:
+        - products
+      security:
+        - cookieAuth: [ ]
+        - basicAuth: [ ]
+        - { }
+      responses:
+        '204':
+          description: No response body
   /api/v1/producttypes/:
     get:
       operationId: producttypes_list
@@ -1616,7 +1755,6 @@ components:
         parent_category:
           type: string
           format: uuid
-          writeOnly: true
           nullable: true
         product_types:
           type: array
@@ -1699,6 +1837,41 @@ components:
         - negative_text
         - positive_text
         - question
+    Data:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        field:
+          allOf:
+            - $ref: '#/components/schemas/Field'
+          readOnly: true
+        field_id:
+          type: string
+          format: uuid
+          writeOnly: true
+        value:
+          type: string
+          description: The value of the field
+      required:
+        - field
+        - field_id
+        - id
+        - value
+    DataUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        value:
+          type: string
+          description: The value of the field
+      required:
+        - id
+        - value
     Field:
       type: object
       properties:
@@ -1727,7 +1900,6 @@ components:
             * `date` - Date
             * `datetime` - Datetime
             * `email` - Email
-            * `file` - File
             * `iban` - Iban
             * `licenseplate` - License Plate
             * `map` - Map
@@ -1784,7 +1956,6 @@ components:
         parent_category:
           type: string
           format: uuid
-          writeOnly: true
           nullable: true
         product_types:
           type: array
@@ -1881,7 +2052,6 @@ components:
             * `date` - Date
             * `datetime` - Datetime
             * `email` - Email
-            * `file` - File
             * `iban` - Iban
             * `licenseplate` - License Plate
             * `map` - Map
@@ -1993,7 +2163,6 @@ components:
             type: string
             format: uuid
           writeOnly: true
-          default: [ ]
         questions:
           type: array
           items:
@@ -2059,6 +2228,51 @@ components:
             type: string
             maxLength: 100
           description: List of keywords for search
+    PatchedProductUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataUpdate'
+        published:
+          type: boolean
+          description: Whether the object is accessible through the API.
+        created_on:
+          type: string
+          format: date-time
+          readOnly: true
+          description: The datetime at which the object was created.
+        updated_on:
+          type: string
+          format: date-time
+          readOnly: true
+          description: The datetime at which the object was last changed.
+        start_date:
+          type: string
+          format: date
+          description: The start date for this product
+        end_date:
+          type: string
+          format: date
+          description: The end date for this product
+        bsn:
+          type: string
+          nullable: true
+          description: The BSN of the product owner. BSN of 8 characters needs a leading
+            0.
+        kvk:
+          type: string
+          nullable: true
+          title: KVK number
+          description: The KVK number of the product owner
+          pattern: ^[0-9]*$
+          maxLength: 8
+          minLength: 8
     PatchedQuestion:
       type: object
       properties:
@@ -2145,6 +2359,68 @@ components:
       required:
         - amount
         - description
+    Product:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        product_type:
+          allOf:
+            - $ref: '#/components/schemas/SimpleProductType'
+          readOnly: true
+        product_type_id:
+          type: string
+          format: uuid
+          writeOnly: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Data'
+        published:
+          type: boolean
+          description: Whether the object is accessible through the API.
+        created_on:
+          type: string
+          format: date-time
+          readOnly: true
+          description: The datetime at which the object was created.
+        updated_on:
+          type: string
+          format: date-time
+          readOnly: true
+          description: The datetime at which the object was last changed.
+        start_date:
+          type: string
+          format: date
+          description: The start date for this product
+        end_date:
+          type: string
+          format: date
+          description: The end date for this product
+        bsn:
+          type: string
+          nullable: true
+          description: The BSN of the product owner. BSN of 8 characters needs a leading
+            0.
+        kvk:
+          type: string
+          nullable: true
+          title: KVK number
+          description: The KVK number of the product owner
+          pattern: ^[0-9]*$
+          maxLength: 8
+          minLength: 8
+      required:
+        - created_on
+        - data
+        - end_date
+        - id
+        - product_type
+        - product_type_id
+        - start_date
+        - updated_on
     ProductType:
       type: object
       properties:
@@ -2201,7 +2477,6 @@ components:
             type: string
             format: uuid
           writeOnly: true
-          default: [ ]
         questions:
           type: array
           items:
@@ -2269,6 +2544,7 @@ components:
           description: List of keywords for search
       required:
         - categories
+        - category_ids
         - conditions
         - content
         - created_on
@@ -2281,6 +2557,58 @@ components:
         - tags
         - uniform_product_name
         - uniform_product_name_id
+        - updated_on
+    ProductUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataUpdate'
+        published:
+          type: boolean
+          description: Whether the object is accessible through the API.
+        created_on:
+          type: string
+          format: date-time
+          readOnly: true
+          description: The datetime at which the object was created.
+        updated_on:
+          type: string
+          format: date-time
+          readOnly: true
+          description: The datetime at which the object was last changed.
+        start_date:
+          type: string
+          format: date
+          description: The start date for this product
+        end_date:
+          type: string
+          format: date
+          description: The end date for this product
+        bsn:
+          type: string
+          nullable: true
+          description: The BSN of the product owner. BSN of 8 characters needs a leading
+            0.
+        kvk:
+          type: string
+          nullable: true
+          title: KVK number
+          description: The KVK number of the product owner
+          pattern: ^[0-9]*$
+          maxLength: 8
+          minLength: 8
+      required:
+        - created_on
+        - data
+        - end_date
+        - id
+        - start_date
         - updated_on
     Question:
       type: object
@@ -2301,6 +2629,10 @@ components:
     SimpleCategory:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
         published:
           type: boolean
           description: Whether the object is accessible through the API.
@@ -2333,6 +2665,7 @@ components:
           description: Image of the category
       required:
         - created_on
+        - id
         - name
         - updated_on
     SimpleProductType:
@@ -2448,7 +2781,6 @@ components:
         - date
         - datetime
         - email
-        - file
         - iban
         - licenseplate
         - map
@@ -2471,7 +2803,6 @@ components:
         * `date` - Date
         * `datetime` - Datetime
         * `email` - Email
-        * `file` - File
         * `iban` - Iban
         * `licenseplate` - License Plate
         * `map` - Map


### PR DESCRIPTION
Adds product to api

- Updated validate method for field (and product) so that it also works on update requests
- added model_to_dict_with_id helper for api tests

#### Product serializer
- Data is created with the product and only the values should be changed. (new data objects can not be added with an update)
- Also needed to limit what fields could be updated (product_type for example)
- Drf fields do not have a create_only attribute so `ProductUpdateSerializer` was added to handle update requests.
